### PR TITLE
Feature: Add default placeholder  in dropdown

### DIFF
--- a/nodes/klicktipp-subscriber-subscribe.html
+++ b/nodes/klicktipp-subscriber-subscribe.html
@@ -15,15 +15,11 @@
 	</div>
 	<div class="form-row">
         <label for="node-input-listId"><i class="fa fa-tags""></i> <span>Opt-in process</span></label>
-        <select id="node-input-listId">
-            <option value="">-- Select Opt-in Process (Optional) --</option>
-        </select>
+        <select id="node-input-listId"></select>
     </div>
     <div class="form-row">
         <label for="node-input-tagId"><i class="fa fa-tag"></i> <span>Tag</span></label>
-        <select id="node-input-tagId">
-            <option value="">-- Select Tag (Optional) --</option>
-        </select>
+        <select id="node-input-tagId"></select>
     </div>
 	<div class="form-row">
 	    <label for="node-input-fields"><i class="fa fa-list"></i> <span>Data fields</span></label>

--- a/nodes/klicktipp-subscriber-tagged.html
+++ b/nodes/klicktipp-subscriber-tagged.html
@@ -5,9 +5,7 @@
 	</div>
     <div class="form-row">
         <label for="node-input-tagId"><i class="fa fa-tag"></i> <span>Tag</span></label>
-        <select id="node-input-tagId">
-            <option disabled value="">-- Select Tag (Required) --</option>
-        </select>
+        <select id="node-input-tagId"></select>
     </div>
 	<div class="form-row">
 	    <label for="node-input-name"><i class="fa fa-tag"></i> <span>Name</span></label>

--- a/nodes/klicktipp-subscriber-untag.html
+++ b/nodes/klicktipp-subscriber-untag.html
@@ -10,9 +10,7 @@
 	</div>
     <div class="form-row">
         <label for="node-input-tagId"><i class="fa fa-tag"></i> <span>Tag</span></label>
-        <select id="node-input-tagId">
-        	<option disabled value="">-- Select Tag (Required) --</option>
-        </select>
+        <select id="node-input-tagId"></select>
     </div>
 	<div class="form-row">
 	    <label for="node-input-name"><i class="fa fa-tag"></i> <span>Name</span></label>

--- a/nodes/klicktipp-subscription-process-get-redirect.html
+++ b/nodes/klicktipp-subscription-process-get-redirect.html
@@ -5,9 +5,7 @@
 	</div>
 	<div class="form-row">
         <label for="node-input-listId"><i class="fa fa-tags""></i> <span>Opt-in process</span></label>
-        <select id="node-input-listId">
-        	<option disabled value="">-- Select Opt-in Process (Required) --</option>
-        </select>
+        <select id="node-input-listId"></select>
     </div>
 	<div class="form-row">
 	    <label for="node-input-email"><i class="fa fa-envelope"></i> <span>Email address</span></label>

--- a/nodes/klicktipp-subscription-process-get.html
+++ b/nodes/klicktipp-subscription-process-get.html
@@ -5,9 +5,7 @@
 	</div>
 	<div class="form-row">
         <label for="node-input-listId"><i class="fa fa-tags""></i> <span>Opt-in process</span></label>
-        <select id="node-input-listId">
-        	<option disabled value="">-- Select Opt-in Process (Required) --</option>
-        </select>
+        <select id="node-input-listId"></select>
     </div>
 	<div class="form-row">
 	   <label for="node-input-name"><i class="fa fa-tag"></i> <span>Name</span></label>

--- a/nodes/klicktipp-tag-delete.html
+++ b/nodes/klicktipp-tag-delete.html
@@ -5,9 +5,7 @@
 	</div>
     <div class="form-row">
         <label for="node-input-tagId"><i class="fa fa-tag"></i> <span>Tag</span></label>
-        <select id="node-input-tagId">
-            <option disabled value="">-- Select Tag (Required) --</option>
-        </select>
+        <select id="node-input-tagId"></select>
     </div>
 	<div class="form-row">
 	    <label for="node-input-name"><i class="fa fa-tag"></i> <span>Name</span></label>

--- a/nodes/klicktipp-tag-get.html
+++ b/nodes/klicktipp-tag-get.html
@@ -5,9 +5,7 @@
 	</div>
     <div class="form-row">
         <label for="node-input-tagId"><i class="fa fa-tag"></i> <span>Tag</span></label>
-        <select id="node-input-tagId">
-            <option disabled value="">-- Select Tag (Required) --</option>
-        </select>
+        <select id="node-input-tagId"></select>
     </div>
 	<div class="form-row">
 	    <label for="node-input-name"><i class="fa fa-tag"></i> <span>Name</span></label>

--- a/nodes/klicktipp-tag-update.html
+++ b/nodes/klicktipp-tag-update.html
@@ -5,9 +5,7 @@
 	</div>
     <div class="form-row">
         <label for="node-input-tagId"><i class="fa fa-tag"></i> <span>Tag</span></label>
-        <select id="node-input-tagId">
-            <option disabled value="">-- Select Tag (Required) --</option>
-        </select>
+        <select id="node-input-tagId"></select>
     </div>
 	<div class="form-row">
 		<label for="node-input-tagName"><i class="fa fa-tags""></i> <span>Name</span></label>

--- a/resources/formUtils.js
+++ b/resources/formUtils.js
@@ -135,8 +135,8 @@ function ktPopulateDropdown($dropdown, selectedItemId, actionUrl) {
 	$dropdown.empty().append(
 		$('<option>', {
 			value: '',
-			text: 'Select an option (optional)',
-			disabled: true,
+			text: 'Select an option',
+			disabled: false,
 			selected: !selectedItemId // Select by default if no item is pre-selected
 		})
 	);


### PR DESCRIPTION
This PR enhances the dropdown functionality for `tagId` and `listId` parameters by:

- Optional Selection: Allowing tagId and listId to remain unselected by providing a default placeholder in the dropdown, making these parameters truly optional;
- Improved Error Handling: When an error occurs (e.g., loading failure), the dropdown now displays an empty option with a placeholder that includes a error message;

![Screenshot 2024-10-25 at 17 20 04](https://github.com/user-attachments/assets/0035a0f0-d602-4fe4-bfee-76950a4b7263)
![Screenshot 2024-10-25 at 17 20 00](https://github.com/user-attachments/assets/6f98d79c-d938-4d1c-8984-0561de869d78)
